### PR TITLE
refined update cycle to run on clock time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.swp
 *.logs
+*.project

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.swp
+*.logs

--- a/main.js
+++ b/main.js
@@ -33,6 +33,12 @@ io.sockets.on('connection', function (socket) {
         data.id = socket.id;
         socket.broadcast.emit('name', data); 
     });
+    
+    // God commands
+    socket.on('god', function(data){
+    	world.godSays(data);
+    });
+    
     socket.on('disconnect', function() {
         // Update our list of players remove me
        socket.broadcast.emit('died', {id: socket.id});

--- a/static/js/world.js
+++ b/static/js/world.js
@@ -2,34 +2,97 @@ var world = function () {
     var grid = [];
     var players =  [];
     var minPlayersToStart = 4;
-    var addPlayer = function(player) {players.push(player);};
+    
     var howManyPlayers = function() {return players.length;};
     var timerId = 0;
     var io = null;
+    var lastTick;
+    // the update interval in ms
+    var cycleSpeedMs = 1000;
+    // the players move at units (direction) per second (rate).
+    var playerRate = 1000;
     
-    var update = function() { 
-        // update ticks
-        console.log("update ran");
-        if (io) {
-            io.sockets.volatile.emit('update', {"hoo": "ray"});
+    // add a player to the world
+    var addPlayer = function(player) {
+    	console.log("add player: " + player.name);
+    	players.push(player);
+    };
+    
+    // update the world state
+    var crank = function(tick) {
+    	// elapsed ticks
+    	var dt = tick - lastTick;
+    	// elapsed per second clock rate (how much time in seconds has elapsed since last cycle)
+    	var dRate = (dt / playerRate);
+        
+        console.log("crank - delta: " + dt + " tick: " + tick);
+        for (var i = 0; i < players.length; i++) {
+        	players[i].px += players[i].dx * dRate;
+        	players[i].py += players[i].dy * dRate;
+        	
+        	console.log("player " + players[i].name + " - (" + players[i].px + "," + players[i].py + ")");
         }
     };
-    var init= function() {
+    
+    // debug
+    var godSays = function(data) {
+    	if (data.message == "startCycle") {
+    		console.log("force cycle start");
+    		startCycle();
+    	}
+    	else if (data.message == "setCycle") {
+    		console.log("set cycle speed");
+    		setCycleSpeed(data.arg1);
+    	}
+    	else if (data.message == "dummyPlayers") {
+    		addPlayer({name:"leo", px:10, py:10, dx:10, dy:2});
+    		addPlayer({name:"mike", px:300, py:10, dx:10, dy:2});
+    		addPlayer({name:"ralph", px:10, py:400, dx:2, dy:-1});
+    		addPlayer({name:"don", px:500, py:500, dx:-2, dy:-2});
+    	}
+    };
+    
+    // synchronous cycle update
+    var update = function() { 
+        // tick tock
+        var tick = (new Date()).getTime();
+        
+        crank(tick);
+        
+        // broadcast world state
+        if (io) {
+            io.sockets.volatile.emit('update', {"tick": tick});
+        }
+        
+        lastTick = tick;
+    };
+    var init = function() {
         if (timerId || howManyPlayers() < minPlayersToStart)
             return;
         
-        timerId = setInterval(world.update, 1000);
+        startCycle();
+    };
+    var startCycle = function() {
+    	lastTick = (new Date()).getTime();
+    	timerId = setInterval(world.update, cycleSpeedMs);
     };
     var setIo = function(pIo) {
         io = pIo;
     };
+    var setCycleSpeed = function(ms) {
+    	clearInterval(timerId);
+    	cycleSpeedMs = ms;
+    	startCycle();
+    }
+    
     
     return {
         addPlayer:addPlayer ,
         howManyPlayers:howManyPlayers,
         update:update,
         init:init,
-        setIo: setIo
+        setIo: setIo,
+        godSays: godSays
     };
 }();
 

--- a/static/simpleClient.html
+++ b/static/simpleClient.html
@@ -86,10 +86,18 @@ Array.prototype.remove = function(from, to) {
       console.log("player Count: " + data.players);
     });
     socket.on('update', function(data) {
-      console.log("Update hoo " + data.hoo);
+      console.log("Update tick " + data.tick);
     });
     $("#save").click(function() {
-      socket.emit('name', { name: $("#name").val() });
+      var stuff = $("#name").val();
+      var words = stuff.split(" ");
+      
+      if (words[0] != "god") {
+      	socket.emit('name', { name: $("#name").val() });
+      }
+      else {
+      	socket.emit('god', {message:words[1],arg1:words[2]})
+      }
     });
     
     $(window).mousemove(function(event) {

--- a/web.config
+++ b/web.config
@@ -1,0 +1,126 @@
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="iisnode" path="main.js" verb="*" modules="iisnode" />
+    </handlers>
+
+    <!--
+      the iisnode section configures the behavior of the node.js IIS module
+      setting values below are defaults
+
+    * node_env - determines the environment (production, development, staging, ...) in which
+      child node processes run; if nonempty, is propagated to the child node processes as their NODE_ENV
+      environment variable; the default is the value of the IIS worker process'es NODE_ENV
+      environment variable
+
+    * nodeProcessCommandLine - command line starting the node executable; in shared
+      hosting environments this setting would typically be locked at the machine scope.
+      
+    * nodeProcessCountPerApplication - number of node.exe processes that IIS will start per application;
+      setting this value to 0 results in creating one node.exe process per each processor on the machine
+      
+    * maxConcurrentRequestsPerProcess - maximum number of reqeusts one node process can
+      handle at a time
+      
+    * maxNamedPipeConnectionRetry - number of times IIS will retry to establish a named pipe connection with a
+      node process in order to send a new HTTP request
+      
+    * namedPipeConnectionRetryDelay - delay in milliseconds between connection retries
+    
+    * maxNamedPipeConnectionPoolSize - maximum number of named pipe connections that will be kept in a connection pool;
+      connection pooling helps improve the performance of applications that process a large number of short lived HTTP requests
+      
+    * maxNamedPipePooledConnectionAge - age of a pooled connection in milliseconds after which the connection is not reused for
+      subsequent requests
+    
+    * asyncCompletionThreadCount - size of the IO thread pool maintained by the IIS module to process asynchronous IO; setting it
+      to 0 (default) results in creating one thread per each processor on the machine
+    
+    * initialRequestBufferSize - initial size in bytes of a memory buffer allocated for a new HTTP request
+    
+    * maxRequestBufferSize - maximum size in bytes of a memory buffer allocated per request; this is a hard limit of
+      the serialized form of HTTP request or response headers block
+      
+    * watchedFiles - semi-colon separated list of files that will be watched for changes; a change to a file causes the application to recycle;
+      each entry consists of an optional directory name plus required file name which are relative to the directory where the main application entry point
+      is located; wild cards are allowed in the file name portion only; for example: "*.js;node_modules\foo\lib\options.json;app_data\*.config.json"
+      
+    * uncFileChangesPollingInterval - applications are recycled when the underlying *.js file is modified; if the file resides
+      on a UNC share, the only reliable way to detect such modifications is to periodically poll for them; this setting
+      controls the polling interval
+      
+    * gracefulShutdownTimeout - when a node.js file is modified, all node processes handling running this application are recycled;
+      this setting controls the time (in milliseconds) given for currently active requests to gracefully finish before the
+      process is terminated; during this time, all new requests are already dispatched to a new node process based on the fresh version
+      of the application
+    
+    * loggingEnabled - controls whether stdout and stderr streams from node processes are captured and made available over HTTP
+    
+    * logDirectoryNameSuffix - suffix of the directory name that will store files with stdout and stderr captures; directly name is created
+      by appending this suffix to the file name of the node.js application; individual log files are stored in that directory, one per node
+      process (in files of the form x.txt, where x is between 0 and nodeProcessCountPerApplication - 1); given a node.js application at
+      http://localhost/node/hello.js, log files would by default be stored at http://localhost/node/hello.js.logs/0.txt (thrugh 3.txt);
+      SECURITY NOTE: if log files contain sensitive information, this setting should be modified to contain enough entropy to be considered
+      cryptographically secure; in most situations, a GUID is sufficient
+      
+    * debuggingEnabled - controls whether the built-in debugger is available
+      
+    * debuggerPortRange - range of TCP ports that can be used for communication between the node-inspector debugger and the debugee; iisnode
+      will round robin through this port range for subsequent debugging sessions and pick the next available (free) port to use from the range
+      
+    * debuggerPathSegment - URL path segment used to access the built-in node-inspector debugger; given a node.js application at
+      http://foo.com/bar/baz.js, the debugger can be accessed at http://foo.com/bar/baz.js/{debuggerPathSegment}, by default
+      http://foo.com/bar/baz.js/debug
+    
+    * maxLogFileSizeInKB - maximum size of a log file in KB; once a log file exceeds this limit it is truncated back to empty
+    
+    * appendToExistingLog - determines whether pre-existing log files are appended to or created fresh when a node process with a given ordinal
+      number starts; appending may be useful to diagnose unorderly node process terminations or recycling
+      
+    * logFileFlushInterval - interval in milliseconds for flushing logs to the log files
+    
+    * devErrorsEnabled - controls how much information is sent back in the HTTP response to the browser when an error occurrs in iisnode;
+      when true, error conditions in iisnode result in HTTP 200 response with the body containing error details; when false,
+      iisnode will return generic HTTP 5xx responses
+      
+    * flushResponse - controls whether each HTTP response body chunk is immediately flushed by iisnode; flushing each body chunk incurs
+      CPU cost but may improve latency in streaming scenarios
+      
+    * enableXFF - controls whether iisnode adds or modifies the X-Forwarded-For request HTTP header with the IP address of the remote host
+    
+    * promoteServerVars - comma delimited list of IIS server variables that will be propagated to the node.exe process in the form of
+      x-iisnode-<server_variable_name> HTTP request headers; for a list of IIS server variables available see
+      http://msdn.microsoft.com/en-us/library/ms524602(v=vs.90).aspx; for example "AUTH_USER,AUTH_TYPE"
+      
+    -->
+    
+    <iisnode
+      node_env="%node_env%"
+      nodeProcessCountPerApplication="1"
+      maxConcurrentRequestsPerProcess="1024"
+      maxNamedPipeConnectionRetry="3"
+      namedPipeConnectionRetryDelay="2000"
+      maxNamedPipeConnectionPoolSize="512"
+      maxNamedPipePooledConnectionAge="30000"
+      asyncCompletionThreadCount="0"
+      initialRequestBufferSize="4096"
+      maxRequestBufferSize="65536"
+      watchedFiles="*.js"
+      uncFileChangesPollingInterval="5000"
+      gracefulShutdownTimeout="60000"
+      loggingEnabled="true"
+      logDirectoryNameSuffix="logs"
+      debuggingEnabled="true"
+      debuggerPortRange="5058-6058"
+      debuggerPathSegment="debug"
+      maxLogFileSizeInKB="128"
+      appendToExistingLog="false"
+      logFileFlushInterval="5000"
+      devErrorsEnabled="true"
+      flushResponse="false"
+      enableXFF="false"
+      promoteServerVars=""
+     />
+
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
1. added web.config and tweaked .gitignore to run node in iis. should not affect anything.
2. added crank function that updates player positions in clock time.
3. added god commands to ease dev and debug of cycle stuff. the following examples can be entered in the text field and clicking 'save' will run it.

god dummyPlayers // adds 4 hardcoded players
god setCycle 500 // sets the update cycle speed to 500 ms - server console will show player updates
god setCycle 100 // speeds up update cycle to 100 ms - server console shows more updates, but players moving at the same clock rate (units per second).
