### PR TITLE
tests!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 0.4
+  - 0.6
+  - 0.7 # development version of 0.8, may be unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - 0.4
   - 0.6
-  - 0.7 # development version of 0.8, may be unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: node_js
 node_js:
   - 0.4
   - 0.6
+# whitelist
+branches:
+  only:
+    - master
+    - dev
+    - testing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 NodeWorld
 =========
 
+[![Build Status](https://secure.travis-ci.org/clintcparker/NodeWorld.png?branch=master)](http://travis-ci.org/clintcparker/NodeWorld)
+
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
+[![Build Status](https://secure.travis-ci.org/clintcparker/NodeWorld.png?branch=master)](http://travis-ci.org/clintcparker/NodeWorld)
+
+
+
 NodeWorld
 =========
 
-[![Build Status](https://secure.travis-ci.org/clintcparker/NodeWorld.png?branch=master)](http://travis-ci.org/clintcparker/NodeWorld)
 
 Usage
 -----

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
       "asyncjs" : "0.0.6"
     },
     "scripts": { 
-    "test": "make test" 
+    "test": "mocha -R spec" 
   },
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
       "asyncjs" : "0.0.6"
     },
     "scripts": { 
-    "test": "mocha -R spec" 
-  },
+    "test": "make test" 
+  }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
       "asyncjs" : "0.0.6"
     },
     "scripts": { 
-    "test": "make test" 
+    "test": "rake test" 
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     {
       "mocha" : "1.0.0",
       "asyncjs" : "0.0.6"
-    }
+    },
+    "scripts": { 
+    "test": "make test" 
+  },
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
       "asyncjs" : "0.0.6"
     },
     "scripts": { 
-    "test": "rake test" 
+    "test": "make test" 
   }
 }

--- a/static/js/player/player.js
+++ b/static/js/player/player.js
@@ -1,0 +1,37 @@
+function Player(details) {
+    // Make sure we instantiate this object
+    if (!(details && details["refId"])){
+        throw "Player reuires a person refernce";    
+    }
+    
+    if (!(this instanceof Player)) {
+        return new Player(details);
+    }
+    
+    
+var color,
+direction,
+id,
+status,
+position;
+
+    var refId;
+    
+    this.getRefId = function() {
+         return refId;   
+    }
+    // end refId
+
+    if (details) {
+        refId = details.refId;
+        
+    }
+}
+
+if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = Player;
+    }
+    exports.testingObj = Player;
+}
+    

--- a/static/js/player/player_test.js
+++ b/static/js/player/player_test.js
@@ -1,0 +1,2 @@
+require('../../../test/c9test');
+require('../../../test/test.player');

--- a/test/test.player.js
+++ b/test/test.player.js
@@ -1,0 +1,13 @@
+var assert = require('assert'),
+    Player = require('./../static/js/player/player');
+  
+ suite('Player', function() {
+     test('Player Instantiation', function() {
+         
+         assert.throws(function() {var player = Player();}, "Player reuires a person refernce", "Player must reference a person");
+         assert.doesNotThrow(function() {var player2 = Player({refId:"someRef"});}, "Player reuires a person refernce", "Player must reference a person");
+         var player2 = Player({refId:"someRef"});
+         assert.equal(player2.getRefId(), "someRef");
+     });
+     
+ });


### PR DESCRIPTION
Travis now works, and the running of the cloud9 tests is super clean. The only thing we'll need to do is setup a travis service hook on the bnowel repo, and then change the tests image to reflect that.
